### PR TITLE
Ajout de Spacy

### DIFF
--- a/apps/back/README.md
+++ b/apps/back/README.md
@@ -14,7 +14,7 @@
 ***https://fastapi.tiangolo.com/#run-it***
 - ```poetry shell``` --> Activation de l'environnement virtuel
 - ```cd back``` --> on va dans le répertoire du serveur
-- ```uvicorn main:app —-reload``` --> on active le serveur
+- ```uvicorn main:app --reload``` --> on active le serveur
 
 ### Test it
 ***https://fastapi.tiangolo.com/tutorial/testing/***
@@ -48,3 +48,8 @@
 - Clicker sur http://127.0.0.1:8000/health 
 - JSON attendu: {"statut":"Serveur OK"}
 - API disponible ici: http://localhost:8000/docs
+
+## Spacy Integration
+Ce serveur va utiliser Spacy pour orchestrer les workflows d'analyse NLP.
+Inspiré de l'exemple d'intégration de projects/integrations/fastapi que l'on peut trouver sur le GitHub d'Explosion: https://github.com/explosion/projects/tree/v3/integrations/fastapi.
+

--- a/apps/back/back/main.py
+++ b/apps/back/back/main.py
@@ -1,12 +1,78 @@
-from typing import Union
-
+from typing import List, Dict, Any
+from enum import Enum
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import spacy
+from spacy.tokens import Doc
 
+
+class ModelName(str, Enum):
+    # Enum of the available models. This allows the API to raise a more specific
+    # error if an invalid model is provided.
+    fr_core_news_sm = "fr_core_news_sm"
+    fr_core_news_md = "fr_core_news_md"
+    fr_core_news_lg = "fr_core_news_lg"
+    fr_dep_news_trf = "fr_dep_news_trf"
+    xx_ent_wiki_sm = "xx_ent_wiki_sm"
+    xx_sent_ud_sm = "xx_sent_ud_sm"
+
+
+DEFAULT_MODEL = ModelName.fr_core_news_sm
+MODEL_NAMES = [model.value for model in ModelName]
+MODELS = {name: spacy.load(name) for name in MODEL_NAMES}
+print(f"Loaded {len(MODEL_NAMES)} models: {MODEL_NAMES}")
+
+
+class Article(BaseModel):
+    # Schema for a single article in a batch of articles to process
+    text: str
+
+
+class RequestModel(BaseModel):
+    articles: List[Article]
+    model: ModelName = DEFAULT_MODEL
+
+
+class ResponseModel(BaseModel):
+    # This is the schema of the expected response and depends on what you
+    # return from get_data.
+
+    class Batch(BaseModel):
+        class Entity(BaseModel):
+            text: str
+            label: str
+            start: int
+            end: int
+
+        text: str
+        ents: List[Entity] = []
+
+    result: List[Batch]
+
+
+def get_data(doc: Doc) -> Dict[str, Any]:
+    """Extract the data to return from the REST API given a Doc object. Modify
+    this function to include other data."""
+    ents = [
+        {
+            "text": ent.text,
+            "label": ent.label_,
+            "start": ent.start_char,
+            "end": ent.end_char,
+        }
+        for ent in doc.ents
+    ]
+    return {"text": doc.text, "ents": ents}
+
+
+# Set up the FastAPI app and define the endpoints
 app = FastAPI(
     title="NLP Server Back",
     summary="Derfulio's favorite app. Nuff said.",
     version="0.2.1",
 )
+app.add_middleware(CORSMiddleware, allow_origins=["*"])
 
 
 @app.get("/")
@@ -19,6 +85,25 @@ async def health_check():
     return {"statut": "Serveur OK"}
 
 
-@app.get("/items/{item_id}")
-async def read_item(item_id: int, q: Union[str, None] = None):
-    return {"item_id": item_id, "q": q}
+@app.get("/models", summary="List all loaded models")
+def get_models() -> List[str]:
+    """Return a list of all available loaded models."""
+    return MODEL_NAMES
+
+
+@app.post("/process/", summary="Process batches of text", response_model=ResponseModel)
+def process_articles(query: RequestModel):
+    """Process a batch of articles and return the entities predicted by the
+    given model. Each record in the data should have a key "text".
+    """
+    nlp = MODELS[query.model]
+    response_body = []
+    texts = (article.text for article in query.articles)
+    for doc in nlp.pipe(texts):
+        response_body.append(get_data(doc))
+    return {"result": response_body}
+
+
+# @app.get("/items/{item_id}")
+# async def read_item(item_id: int, q: Union[str, None] = None):
+#   return {"item_id": item_id, "q": q}

--- a/apps/back/pyproject.toml
+++ b/apps/back/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "back"
-version = "0.2.0"
+version = "0.3.0"
 description = ""
 authors = ["Derfulio <36664091+Derfulio@users.noreply.github.com>"]
 readme = "README.md"
@@ -9,7 +9,7 @@ readme = "README.md"
 python = "^3.11"
 fastapi = "^0.104.1"
 uvicorn = {extras = ["standard"], version = "^0.23.2"}
-spacy = {extras = ["cuda12x", "lookups", "transformers"], version = "^3.7.2"}
+spacy = {extras = ["lookups", "transformers"], version = "^3.7.2"}
 fr-core-news-sm = {url = "https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.7.0/fr_core_news_sm-3.7.0-py3-none-any.whl"}
 fr-core-news-md = {url = "https://github.com/explosion/spacy-models/releases/download/fr_core_news_md-3.7.0/fr_core_news_md-3.7.0-py3-none-any.whl"}
 fr-core-news-lg = {url = "https://github.com/explosion/spacy-models/releases/download/fr_core_news_lg-3.7.0/fr_core_news_lg-3.7.0-py3-none-any.whl"}

--- a/apps/back/pyproject.toml
+++ b/apps/back/pyproject.toml
@@ -9,6 +9,13 @@ readme = "README.md"
 python = "^3.11"
 fastapi = "^0.104.1"
 uvicorn = {extras = ["standard"], version = "^0.23.2"}
+spacy = {extras = ["cuda12x", "lookups", "transformers"], version = "^3.7.2"}
+fr-core-news-sm = {url = "https://github.com/explosion/spacy-models/releases/download/fr_core_news_sm-3.7.0/fr_core_news_sm-3.7.0-py3-none-any.whl"}
+fr-core-news-md = {url = "https://github.com/explosion/spacy-models/releases/download/fr_core_news_md-3.7.0/fr_core_news_md-3.7.0-py3-none-any.whl"}
+fr-core-news-lg = {url = "https://github.com/explosion/spacy-models/releases/download/fr_core_news_lg-3.7.0/fr_core_news_lg-3.7.0-py3-none-any.whl"}
+fr-dep-news-trf = {url = "https://github.com/explosion/spacy-models/releases/download/fr_dep_news_trf-3.7.2/fr_dep_news_trf-3.7.2-py3-none-any.whl"}
+xx-ent-wiki-sm = {url = "https://github.com/explosion/spacy-models/releases/download/xx_ent_wiki_sm-3.7.0/xx_ent_wiki_sm-3.7.0-py3-none-any.whl"}
+xx-sent-ud-sm = {url = "https://github.com/explosion/spacy-models/releases/download/xx_sent_ud_sm-3.7.0/xx_sent_ud_sm-3.7.0-py3-none-any.whl"}
 
 
 [tool.poetry.group.test.dependencies]

--- a/apps/back/tests/test_main.py
+++ b/apps/back/tests/test_main.py
@@ -9,3 +9,4 @@ def test_health_check():
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"statut": "Serveur OK"}
+

--- a/apps/back/tests/test_spacy.py
+++ b/apps/back/tests/test_spacy.py
@@ -1,0 +1,14 @@
+import unittest
+
+from back.main import MODELS
+
+
+class TestModel(unittest.TestCase):
+
+    def test_models_ok(self):
+        for model in MODELS:
+            assert (model != None)
+            print(str(model), "is available")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Inspiré de l'exemple d'Explosion.ai: https://github.com/explosion/projects/tree/v3/integrations/fastapi

Les modèles par défaut sont téléchargés à l'installation via poetry. A voir si on ne devrait pas précharger les modèles.

Rajout des commandes ```/process``` pour lancer une extraction et ```/models``` pour avoir la liste des models disponibles